### PR TITLE
Small fix to remove an error in alyson

### DIFF
--- a/src/main/java/life/genny/gennyproxy/repository/GoogleMapRepository.java
+++ b/src/main/java/life/genny/gennyproxy/repository/GoogleMapRepository.java
@@ -20,6 +20,15 @@ public class GoogleMapRepository {
     public String retrieveGoogleMap(String apiKey){
         return webClient.get(mapPath)
                 .setQueryParam("key", apiKey)
+                      /*
+                 * The google api takes a paramter 'callback' that gets called
+                 * when alyson loads the maps API. We don't use this feature,
+                 * but the api throws an error when callback is not included.
+                 * 
+                 * To address this, passing 'Function.prototype' into 'callback' means
+                 * that nothing will happen on alyson when the callback is called. (Function.prototype is a noop built into js)
+                 */
+                .setQueryParam("callback", "Function.prototype")
                 .setQueryParam("libraries","places,drawing")
                 .send()
                 .await()


### PR DESCRIPTION
The google api takes a paramter 'callback' that gets called when alyson loads the maps API. We don't use this feature, but the api throws an error when callback is not included.

To address this, passing 'Function.prototype' into 'callback' means that nothing will happen on alyson when the callback is called. (Function.prototype is a noop built into js)